### PR TITLE
exposing-actuator-endpoints

### DIFF
--- a/mycoolapp/pom.xml
+++ b/mycoolapp/pom.xml
@@ -33,6 +33,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/mycoolapp/src/main/resources/application.properties
+++ b/mycoolapp/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 spring.application.name=mycoolapp
+#Use wildcard "*" to expose all endpoints
+management.endpoints.web.exposure.include=*
+management.info.env.enabled=true
+
+info.app.name=My Super Cool App
+info.app.description=A crazy fun app, wohoo!!
+info.app.version=1.0.0


### PR DESCRIPTION
SpringBoot Actuators are used for providing application health status and performance data. 